### PR TITLE
Add install-open-ssl to install-deps recipe

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -126,7 +126,7 @@ install-deps install-libsndfile::
 	@echo Done Installing libsndfile
 	@echo ======================================
 
-install-openssl::
+install-deps install-openssl::
 	@echo ======================================
 	@echo Start Installing OpenSSL
 	@echo ======================================


### PR DESCRIPTION
I found that install-deps wasn't installing openssl on build (and presumably any machine that runs install-deps).  This is my proposed fix, Sam.
